### PR TITLE
fix: make entire experiment card clickable

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -324,10 +324,10 @@ section h2 {
 .post-card .card-link {
   position: absolute;
   inset: 0;
-  z-index: 1;
+  z-index: 2;
 }
 .post-card .card-body,
-.post-card .card-image { position: relative; z-index: 2; }
+.post-card .card-image { position: relative; z-index: 1; }
 .post-card .card-actions .btn { position: relative; z-index: 3; }
 
 /* Vertical post-style card (image on top) */


### PR DESCRIPTION
## Summary
- Fixes the z-index ordering of the card overlay link so clicking anywhere on an experiment card (image, title, description) navigates to the article
- Previously, `card-body` and `card-image` had a higher z-index than the overlay link, blocking clicks — only the "Learn more" button worked
- Now the overlay link sits at z-index 2 (above content at z-index 1), with the button at z-index 3 so it remains independently clickable

## Test plan
- [ ] Visit `/experiments/` and click on a card image → should navigate to the article
- [ ] Click on the card title/description → should navigate to the article
- [ ] Click "Learn more" button → should still navigate to the article

🤖 Generated with [Claude Code](https://claude.com/claude-code)